### PR TITLE
Update all repo names

### DIFF
--- a/modules/gcp-helpers/README.md
+++ b/modules/gcp-helpers/README.md
@@ -9,7 +9,7 @@ This module contains helper scripts that automate common GCP tasks:
 You can install the helpers using the [Gruntwork Installer](https://github.com/gruntwork-io/gruntwork-installer):
 
 ```bash
-gruntwork-install --module-name "gcp-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.0.1"
+gruntwork-install --module-name "gcp-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --tag "v0.0.1"
 ```
 
 We recommend running this command in the `dependencies` section of `circle.yml`:


### PR DESCRIPTION
_**This PR was created by git-xargs. See https://github.com/gruntwork-io/prototypes/pull/152 for context.**_ We recently renamed all of our repos to follow the Terraform registry format of  (e.g., ). This PR does a search & replace to update all references to these repos to the new names. GitHub can handle redirects, so in theory, everything should work fine with the old names, but there were so many renames, that to reduce confusion, this will update most of our references to the proper values.