### PR TITLE
Add Ubuntu image + remove gcloud update from CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,8 @@ env: &env
     GOLANG_VERSION: 1.14
 
 defaults: &defaults
-  machine: true
+  machine:
+    image: ubuntu-2004:202104-01
   <<: *env
 
 install_gruntwork_utils: &install_gruntwork_utils


### PR DESCRIPTION
The python version that the machine executor was using before isn't compatible with the latest gcloud package. 

Python versions supported by the https://pypi.org/project/gcloud/:
<img width="176" alt="Screen Shot 2021-07-13 at 20 41 22" src="https://user-images.githubusercontent.com/9384479/125507392-81028a34-3d85-4d03-bd9b-bdae39198cfe.png">

This PR changes the machine image to use Ubuntu and removes the update job for `gcloud`. The current `gcloud` version for this image is 337.0.0 (2021-04-20) while the latest one is 348.0.0 (2021-07-13).
